### PR TITLE
Add URLQuery parameters to test deep linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+package-lock.json
+.idea/

--- a/index.js
+++ b/index.js
@@ -1,6 +1,29 @@
 const { UrlUtils } = require('xdl');
 
 let url;
+
+function getUrlQueryFromDictionary(dictionary) {
+    let array = [];
+    for (let property in dictionary) {
+        let encodedKey = encodeURIComponent(property);
+        let encodedValue = encodeURIComponent(dictionary[property]);
+        array.push(encodedKey + "=" + encodedValue);
+    }
+    array = array.join("&");
+    return array;
+}
+
+
+function addUrlParams(url, params) {
+    if (params && params.urlQueryString) {
+        const urlParams = params.urlQueryString;
+        if (urlParams != null) {
+            url = url + "?" + getUrlQueryFromDictionary(urlParams);
+        }
+    }
+    return url;
+}
+
 const getAppUrl = async () => {
   if (!url) {
     url = await UrlUtils.constructManifestUrlAsync(process.cwd());
@@ -19,7 +42,8 @@ const getAppHttpUrl = async () => {
 };
 
 const reloadApp = async (params) => {
-  const url = await getAppUrl();
+  let url = await getAppUrl();
+  url = addUrlParams(url, params);
   await device.launchApp({
     permissions: params && params.permissions,
     newInstance: true,


### PR DESCRIPTION
An item I was looking to test with Expo and Detox was the deep linking by receiving a set of URL parameters when initially opening the application. Not sure if it is helpful for anyone else, but I created a version where a parameter can be passed into the reloadApp() function to simulate the url creation. 

For instance, if I wanted to simulate the user clicking on myapp://+?id=1000, I can now pass in the following:

```javascript
let params = {
        urlQueryString: {
            id:"1000"
        }
    };
await reloadApp(params);
```
